### PR TITLE
feat(nvim-tree): Replace `netrw` with `nvim-tree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog], and this project adheres to [SemVer].
 
 ## [unreleased]
 
+### Added
+
+- Replace `netrw` with `nvim-tree` ([PR 6])
+  - `<LEADER>e` to toggle the file tree on or off
+  - `q` to close the file tree
+  - `o` open a file in the editor or expand a directory in the tree
+  - `d` to delete a file
+  - `r` to rename a file or directory
+  - `c` to copy a file or directory
+  - `x` to cut a file or directory
+  - `p` paste a copy or cut file or directory
+  - `y` to yank a file or directory name
+
 ### Changed
 
 - In `normal` mode, show hover info using `Shift+K` instead of `<LEADER>k`
@@ -276,6 +289,6 @@ The format is based on [Keep a Changelog], and this project adheres to [SemVer].
 [v0.1.0]: https://github.com/DrOptix/typewriter/releases/tag/v0.1.0
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [SemVer]: https://semver.org/spec/v2.0.0.html
-
 [PR 2]: https://github.com/DrOptix/typewriter/pull/2
 [PR 5]: https://github.com/DrOptix/typewriter/pull/5
+[PR 6]: https://github.com/DrOptix/typewriter/pull/6

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -17,6 +17,7 @@
   "nvim-lspconfig": { "branch": "master", "commit": "8121483b8132b7053120fafd83728178fb3febf6" },
   "nvim-nio": { "branch": "master", "commit": "a428f309119086dc78dd4b19306d2d67be884eee" },
   "nvim-tmux-navigation": { "branch": "main", "commit": "4898c98702954439233fdaf764c39636681e2861" },
+  "nvim-tree.lua": { "branch": "master", "commit": "6709463b2d18e77f7a946027917aa00d4aaed6f4" },
   "nvim-treesitter": { "branch": "master", "commit": "622a4a6ba76d1de52b72a965159213ae655b4ac7" },
   "nvim-web-devicons": { "branch": "master", "commit": "5740b7382429d20b6ed0bbdb0694185af9507d44" },
   "plenary.nvim": { "branch": "master", "commit": "2d9b06177a975543726ce5c73fca176cedbffe9d" },

--- a/lua/typewriter/plugins/nvim-tree.lua
+++ b/lua/typewriter/plugins/nvim-tree.lua
@@ -1,0 +1,6 @@
+return {
+	"nvim-tree/nvim-tree.lua",
+	dependencies = {
+		"nvim-tree/nvim-web-devicons",
+	},
+}

--- a/lua/typewriter/plugins/nvim-tree.lua
+++ b/lua/typewriter/plugins/nvim-tree.lua
@@ -1,3 +1,6 @@
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
 return {
 	"nvim-tree/nvim-tree.lua",
 	dependencies = {

--- a/lua/typewriter/plugins/nvim-tree.lua
+++ b/lua/typewriter/plugins/nvim-tree.lua
@@ -3,6 +3,13 @@ return {
 	dependencies = {
 		"nvim-tree/nvim-web-devicons",
 	},
+	keys = function()
+		local nvim_tree = require("nvim-tree")
+
+		return {
+			{ "<LEADER>e", ":NvimTreeFindFileToggle<CR>", desc = "Toggle file tree" },
+		}
+	end,
 	opts = {
 		disable_netrw = true,
 		hijack_netrw = true,

--- a/lua/typewriter/plugins/nvim-tree.lua
+++ b/lua/typewriter/plugins/nvim-tree.lua
@@ -1,9 +1,39 @@
-vim.g.loaded_netrw = 1
-vim.g.loaded_netrwPlugin = 1
-
 return {
 	"nvim-tree/nvim-tree.lua",
 	dependencies = {
 		"nvim-tree/nvim-web-devicons",
+	},
+	opts = {
+		disable_netrw = true,
+		hijack_netrw = true,
+		hijack_cursor = true,
+		hijack_unnamed_buffer_when_opening = false,
+		view = {
+			float = {
+				enable = true,
+				open_win_config = function()
+					local screen_w = vim.opt.columns:get()
+					local screen_h = vim.opt.lines:get() - vim.opt.cmdheight:get()
+					local w_h = math.floor(0.9 * screen_w)
+					local s_h = math.floor(0.9 * screen_h)
+					local center_x = (screen_w - w_h) / 2
+					local center_y = ((vim.opt.lines:get() - s_h) / 5) - vim.opt.cmdheight:get()
+					return {
+						border = "rounded",
+						relative = "editor",
+						row = center_y,
+						col = center_x,
+						width = w_h,
+						height = s_h,
+					}
+				end,
+			},
+			width = function()
+				return math.floor(vim.opt.columns:get() * 5)
+			end,
+		},
+		filesystem_watchers = {
+			enable = true,
+		},
 	},
 }


### PR DESCRIPTION
**Issue**: #3 (nvim-tree: Replace `netrw` with `nvim-tree`)

## Description

Replaced `netrw` with `nvim-tree`.

When a a file is opened it opens straight into the editor, but when a directory
is opened, then a full screen file tree is displayed.

Most of the required keybindings are covered by default `nvim-tree` keybindings.
I had to define only one custom key binding to toggle the file tree using
`<LEADER>e`.

When the initial full screen file tree is toggled it will hide and expose an
unnamed buffer. When the file tree is toggled from a file it will displayed in a
floating window covering 90% of the screen.

Closes #3
