### PR TITLE
fix(fileman): Fix file opening when using multi splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog], and this project adheres to [SemVer].
 ### Fixes
 
 - Fix LSP based formatting, tested with C# and Rust code ([PR 2])
+- Fix file opening by opening the file in the last active split ([PR 9])
 
 ## [v0.8.0]
 
@@ -296,3 +297,4 @@ The format is based on [Keep a Changelog], and this project adheres to [SemVer].
 [PR 2]: https://github.com/DrOptix/typewriter/pull/2
 [PR 5]: https://github.com/DrOptix/typewriter/pull/5
 [PR 6]: https://github.com/DrOptix/typewriter/pull/6
+[PR 9]: https://github.com/DrOptix/typewriter/pull/9

--- a/lua/typewriter/plugins/fileman/nvim-tree.lua
+++ b/lua/typewriter/plugins/fileman/nvim-tree.lua
@@ -3,13 +3,9 @@ return {
 	dependencies = {
 		"nvim-tree/nvim-web-devicons",
 	},
-	keys = function()
-		local nvim_tree = require("nvim-tree")
-
-		return {
-			{ "<LEADER>e", ":NvimTreeFindFileToggle<CR>", desc = "Toggle file tree" },
-		}
-	end,
+	keys = {
+		{ "<LEADER>e", ":NvimTreeFindFileToggle<CR>", desc = "Toggle file tree" },
+	},
 	opts = {
 		disable_netrw = true,
 		hijack_netrw = true,

--- a/lua/typewriter/plugins/fileman/nvim-tree.lua
+++ b/lua/typewriter/plugins/fileman/nvim-tree.lua
@@ -11,6 +11,14 @@ return {
 		hijack_netrw = true,
 		hijack_cursor = true,
 		hijack_unnamed_buffer_when_opening = false,
+		actions = {
+			open_file = {
+				quit_on_open = true,
+				window_picker = {
+					enable = false,
+				},
+			},
+		},
 		view = {
 			float = {
 				enable = true,
@@ -34,9 +42,6 @@ return {
 			width = function()
 				return math.floor(vim.opt.columns:get() * 5)
 			end,
-		},
-		filesystem_watchers = {
-			enable = true,
 		},
 	},
 }


### PR DESCRIPTION
By disabling the window picker `nvim-tree` will open the file in the
last active window.

This PR also includes a small refactoring for the `keys`, where it
is no longer a function, but a Lua table.

Closed #8